### PR TITLE
Add additional user statistics to administrator user dashboard - close #44

### DIFF
--- a/app/blueprints/admin.py
+++ b/app/blueprints/admin.py
@@ -36,6 +36,18 @@ from app.__init__ import admin_required
 
 admin_bp = Blueprint('admin', __name__, url_prefix='/admin', template_folder='templates')
 
+# Utility function(s)
+def get_last_attended_date(user):
+        """ Get date of last attended meeting for the given user. """
+        # Query the Meetings table
+        last_meeting = db.session.query(Meetings.event_start)\
+            .join(Attendees, Meetings.id == Attendees.meeting)\
+            .filter(Attendees.username == user.username)\
+            .filter(Meetings.event_start != None)\
+            .order_by(Meetings.event_start.desc())\
+            .first()
+        return last_meeting[0] if last_meeting else None
+
 # Admin web routes.
 @admin_bp.route("/dashboard/<int:meeting_id>/")
 @login_required
@@ -443,6 +455,15 @@ def event_delete(meeting_id):
 def users_list():
     """ Show the users index page."""
     all_users = Users.query.all()
+    for user in all_users:
+        # Get the number of meetings attended by each user.
+        user.meetings_attended = Attendees.query.filter_by(username = user.username).count()
+        # Get the date of the last meeting attended by each user.
+        last_attended_meeting = get_last_attended_date(user)
+        if last_attended_meeting is not None:
+            user.last_checkin = last_attended_meeting
+        else:
+            user.last_checkin = None
     return render_template("admin/users.html", page_title = "Users", users = all_users)
 
 @admin_bp.route("/users/reset-password/<int:user_id>/", methods = ["POST"])

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -15,6 +15,8 @@
                     <th scope="col">Username</th>
                     <th scope="col">Start Semester</th>
                     <th scope="col">End Semester</th>
+                    <th scope="col">Meetings Attended</th>
+                    <th scope="col">Last Check-in Date</th>
                     <th scope="col">Role</th>
                     <th scope="col">Reset Password</th>
                     <th scope="col">MFA Status</th>
@@ -28,6 +30,8 @@
                         <td>{{ user.username }}</td>
                         <td>{{ user.joined|default("N/A", true) }}</td>
                         <td>{{ user.graduated|default("N/A", true) }}</td>
+                        <td>{{ user.meetings_attended }}</td>
+                        <td>{{ user.last_checkin|default("N/A", true) }}</td>
                         <td>
                             <div class="d-flex justify-content-left">
                                 {{ user.role|capitalize }}


### PR DESCRIPTION
Resolve the GitHub issue requesting additional user statistics be displayed on the administrator-only user data dashboard. Add number of meetings attended and last meeting attendance date.