### PR TITLE
Task/remove obsolete env fields

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -19,8 +19,7 @@ ENFORCE_USERNAMES = False
 USERNAME_EMAIL_DOMAIN = ""
 REQUIRE_USERNAME_AS_EMAIL = True
 
-# Databse Details
-SQLALCHEMY_DATABASE_URI = "postgresql://admin:password@db:5432/acm-meetings-db"
+# Security Details
 SECRET_KEY = ""
 
 # reCAPTCHA Details - https://www.google.com/recaptcha/admin

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -147,11 +147,6 @@ def create_app():
                                 "require_username_as_email": os.getenv("REQUIRE_USERNAME_AS_EMAIL")
                             }
     app.context["source"] = os.getenv("GITHUB_SOURCE")
-    app.logs["error"] = os.getenv("ERROR_LOG_PATH")
-    app.logs["login"] = os.getenv("LOGIN_LOG_PATH")
-    app.logs["full"] = os.getenv("FULL_LOG_PATH")
-    app.base_url = os.getenv("BASE_URL")
-    app.storage = os.getenv("STORE_PATH")
 
     # Define the app context processor.
     @app.context_processor

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -34,7 +34,6 @@ To get a local copy up and running follow these simple example steps.
 | ENFORCE_USERNAMES | Whether to enforce username email domain restriction. Set to "True" to enforce, "False" to not enforce. |
 | USERNAME_EMAIL_DOMAIN | The email domain to restrict usernames to, if ENFORCE_USERNAMES is set to "True". |
 | REQUIRE_USERNAME_AS_EMAIL | Whether to require users to use their email as their username. Set to "True" to require, "False" to not require.
-| SQLALCHEMY_DATABASE_URI | The URI for the PostgreSQL database. This should be in the format: "postgresql://admin:password@db:5432/acm-meetings-db" where "password" is replaced with the password you set for the PostgreSQL database in the docker-compose.yml file. |
 | SECRET_KEY | A secret key for the Flask application. This can be any random string. |
 | RECAPTCHA_SITE_KEY | The site key for Google reCAPTCHA. This is required to enable the reCAPTCHA on the user registration page. You can obtain a site key by registering your site with Google reCAPTCHA at https://www.google.com/recaptcha/admin/create. |
 | RECAPTCHA_SECRET_KEY | The secret key for Google reCAPTCHA. This is required to enable the reCAPTCHA on the user registration page. Obtain this key when obtaining the above `RECAPTCHA_SITE_KEY`. |


### PR DESCRIPTION
Resolve issue #49 by updating `app/.env` and `app/__init__.py`, as well as removing the associated data from the table in `quickstart.md`. The following field(s) no longer are in .env:

* SQLALCHEMY_DATABASE_URI - duplicate in `docker-compose.yml` is preferable configuration location. 