### PR TITLE
hide vote count from users

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -141,7 +141,6 @@
                                       {% endif %}
                                       <label class="form-check-label" for="option_{{ option.id }}">
                                         {{ option.option_text }}
-                                        <span class="badge bg-secondary ms-2">{{ option.votes }} votes</span>
                                       </label>
                                     </div>
                                   {% endfor %}


### PR DESCRIPTION
@lefkovitzj This fix hides voters from seeing other peoples votes. Closes and fixes #83.