### PR TITLE
poll does not render if user is not logged in

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -70,6 +70,7 @@
     <div class="row">
       <aside class="col-sm-4">
         <section class="mb-5">
+        {% if current_user.is_authenticated %}  
           <h2>Existing Polls</h2>
           {% if polls %}
             <div class="list-group">
@@ -211,6 +212,7 @@
           {% else %}
             <p class="text-muted">No polls created yet.</p>
           {% endif %}
+        {% endif %}  
         </section>
       </aside>
     </div>


### PR DESCRIPTION
@lefkovitzj Added if statement to prevent polls from being rendered if a user is not logged in. Fixes and closes #113.