### PR TITLE
Bug/fix quickstart md header typo

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,7 +4,7 @@
 <div align="center">
 <h3 align="center">Quick Start - ACM Meeting Records</h3>
   <p align="center">
-    An administrator's gudie to the web app system for recording attendance and notes for ACM meetings.
+    An administrator's guide to the web app system for recording attendance and notes for ACM meetings.
     <br />
   </p>
 </div>


### PR DESCRIPTION
Correct a typo in the header for `quickstart.md`, changing "gudie" to "guide".
This closes issue #121.