### PR TITLE
Task/add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug Report
+about: Report an error or unexpected behavior to help us improve.
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Location of the Bug
+* **File/Feature:** [e.g., login_page.py or Checkout Feature]
+* **Version:** [e.g., v1.2.0, or "Latest"]
+
+## Description of the Bug
+*What is the unexpected or broken behavior? Please provide a clear and concise description.*
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Intended Functionality
+*What should have happened instead? (If already known, otherwise comments will be added to determine intended functionality)*
+
+---
+
+## Acceptance Criteria & Solution Requirements
+*To close this issue, the following must be met:*
+- [ ] 1. Application runs as expected (bug is resolved without breaking existing features).
+- [ ] 2. Code quality metrics are maintained, and linting has been considered in development.
+- [ ] 3. Testing metrics are maintained, and tests have been updated/added wherever relevant during development.
+- [ ] 4. Documentation has been updated to reflect the changes made during development.
+- [ ] 5. Any other requirements that are specific to this issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: New Feature Request
+about: Suggest an idea or a new capability for this project.
+title: '[FEATURE] '
+labels: enhancement
+assignees: ''
+---
+
+## Feature Description
+*What should the feature do? Please describe the behavior or functionality you are looking for.*
+
+## Why It's Worth Implementing
+*What problem does this solve? Why is this feature valuable to the project, maintainers or users?*
+
+---
+
+## Acceptance Criteria & Solution Requirements
+*To close this issue, the following must be met (can be finalized in the comments):*
+- [ ] 1. Application runs as expected with the new feature integrated seamlessly.
+- [ ] 2. Code quality metrics are maintained, and linting has been considered in development.
+- [ ] 3. Testing metrics are maintained, and tests have been updated/added wherever relevant during development.
+- [ ] 4. Documentation has been updated to reflect the changes made during development.
+- [ ] 5. Any other requirements that are specific to this issue.


### PR DESCRIPTION
Add templates for GitHub issues reporting bugs or requesting new features.

Closes #139.