### PR TITLE
Feature/add ghcr GitHub action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main", "feature/add-ghcr-github-action" ]
+    branches: [ "main" ]
 
 jobs:
   build:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,13 +2,16 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "feature/add-ghcr-github-action" ]
 
 jobs:
-
   build:
-
     runs-on: ubuntu-latest
+    
+    # Required permissions to write to GHCR
+    permissions:
+      contents: read
+      packages: write
 
     steps:
     - uses: actions/checkout@v4
@@ -17,12 +20,18 @@ jobs:
     - name: Set up Docker variables
       id: vars
       run: |
+        # Convert repo owner to lowercase because GHCR requires lowercase namespaces
+        OWNER_LOWER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+        echo "GHCR_IMAGE_NAME=ghcr.io/${OWNER_LOWER}/acm-meeting-records" >> $GITHUB_OUTPUT
         echo "DOCKER_IMAGE_NAME=acmatudayton/acm-meeting-records" >> $GITHUB_OUTPUT
         echo "TAG=$(date +%s)" >> $GITHUB_OUTPUT
     
-    # 2. Build the Docker image
+    # 2. Build and Tag the Docker images
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag ${{ steps.vars.outputs.DOCKER_IMAGE_NAME }}:${{ steps.vars.outputs.TAG }}
+      run: |
+        docker build . --file Dockerfile \
+          --tag ${{ steps.vars.outputs.DOCKER_IMAGE_NAME }}:${{ steps.vars.outputs.TAG }} \
+          --tag ${{ steps.vars.outputs.GHCR_IMAGE_NAME }}:${{ steps.vars.outputs.TAG }}
 
     # 3. Log in to Docker Hub
     - name: Log in to Docker Hub
@@ -31,6 +40,17 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PAT }}
 
-    # 4. Push the image to Docker Hub
-    - name: Push the image
+    # 4. Log in to GHCR
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    # 5. Push the images
+    - name: Push to Docker Hub
       run: docker push ${{ steps.vars.outputs.DOCKER_IMAGE_NAME }}:${{ steps.vars.outputs.TAG }}
+
+    - name: Push to GHCR
+      run: docker push ${{ steps.vars.outputs.GHCR_IMAGE_NAME }}:${{ steps.vars.outputs.TAG }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
 <a id="readme-top"></a>
+<!-- PROJECT BADGES -->
+[![Contributors](https://img.shields.io/github/contributors/acm-udayton/ACM-Meeting-Records.svg?style=for-the-badge)](https://github.com/acm-udayton/ACM-Meeting-Records/graphs/contributors)
+[![GitHub stars](https://img.shields.io/github/stars/acm-udayton/ACM-Meeting-Records.svg?style=for-the-badge)](https://github.com/acm-udayton/ACM-Meeting-Records/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/acm-udayton/ACM-Meeting-Records.svg?style=for-the-badge)](https://github.com/acm-udayton/ACM-Meeting-Records/network)
+[![GitHub issues](https://img.shields.io/github/issues/acm-udayton/ACM-Meeting-Records.svg?style=for-the-badge)](https://github.com/acm-udayton/ACM-Meeting-Records/issues)
+[![GitHub license](https://img.shields.io/github/license/acm-udayton/ACM-Meeting-Records.svg?style=for-the-badge)](https://github.com/acm-udayton/ACM-Meeting-Records/blob/main/LICENSE.txt)
+[![Docker Hub](https://img.shields.io/badge/docker%20hub-2496ed?style=for-the-badge&logo=docker&logoColor=white)](https://hub.docker.com/r/acmatudayton/acm-meeting-records)
+[![GHCR](https://img.shields.io/badge/ghcr-24292e?style=for-the-badge&logo=github&logoColor=white)](https://github.com/acm-udayton/ACM-Meeting-Records/pkgs/container/ACM-Meeting-Records)
+
+
 <!-- PROJECT HEADER -->
 <br />
 <div align="center">

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -835,7 +835,7 @@ For precise configuration details, please consult the file at ```.github/workflo
 
 <details>
 <summary id="docker-image-ci"><strong>Docker Image CI</strong></summary>
-This workflow is only triggered on successful pushes to the repository's main branch. It will automatically use the Dockerfile to build a new image for the web container. It will also use GitHub secrets (must be configured by an ACM officer with Organization manager access on GitHub) to publish this image to DockerHub. This ultimately serves the purpose of ensuring that the public build of the web app is a stable release, never a release candidate or development version.
+This workflow is only triggered on successful pushes to the repository's main branch. It will automatically use the Dockerfile to build a new image for the web container. It will also use GitHub secrets (must be configured by an ACM officer with Organization manager access on GitHub) to publish this image to DockerHub as well as GitHub Container Registry (GHCR). This ultimately serves the purpose of ensuring that the public build of the web app is a stable release, never a release candidate or development version.
 <br><br>
 
 For precise configuration details, please consult the file at ```.github/workflows/docker-image.yml```.


### PR DESCRIPTION
This pull request implements a GitHub issue relating to the CI/CD pipeline:

* Add another GitHub action to publish to GitHub Container Registry as well as to Docker Hub.
* Also add the container registry links/badges to the GitHub README.md file for increased visibility.

Closes #130
