### PR TITLE
fixed typo in warning message when creating an account that already exists

### DIFF
--- a/app/blueprints/auth.py
+++ b/app/blueprints/auth.py
@@ -115,7 +115,7 @@ def sign_up():
         if Users.query.filter_by(username = uname).first() is not None:
             flash(
                 "User creation failed. Username already registered. "
-                "Try logging in instead or contact an administrator."
+                "Try logging in instead or contacting an administrator."
                 , "danger"
                 )
             return redirect(url_for("auth.sign_up"))


### PR DESCRIPTION
When a user attempts to create an account with an email that already has an account associated with it, there was a minor grammatical issue. Changed contact to contacting. 

Main part of #69 was fixed in another commit. 

Closes and fixes #69.