### PR TITLE
require CSRF-protected POSTs for sensitive actions

### DIFF
--- a/app/blueprints/admin.py
+++ b/app/blueprints/admin.py
@@ -165,7 +165,7 @@ def event_start(meeting_id):
             }
             return jsonify(return_data), 400
 
-@admin_bp.route("/reset-code/<int:meeting_id>/")
+@admin_bp.route("/reset-code/<int:meeting_id>/", methods = ["POST"])
 @login_required
 @admin_required
 def reset_code(meeting_id):

--- a/app/blueprints/mfa.py
+++ b/app/blueprints/mfa.py
@@ -37,27 +37,52 @@ from app.models import Users, RecoveryCodes
 mfa_bp = Blueprint('mfa', __name__, template_folder='templates')
 
 
-@mfa_bp.route('/reset-recovery-codes/', methods=['GET'])
+def _generate_recovery_codes(user_id):
+    """Replace a user's recovery codes and return their plaintext values once."""
+    RecoveryCodes.query.filter_by(user_id=user_id).delete()
+    code_values = []
+
+    for _ in range(10):
+        new_code = RecoveryCodes(user_id=user_id)
+        code_values.append(new_code.generate_code())
+        db.session.add(new_code)
+
+    return "\n".join(
+        "\t".join(code_values[index:index + 2])
+        for index in range(0, len(code_values), 2)
+    )
+
+
+def _render_totp_setup(secret, form=None):
+    """Render the TOTP setup page for a pending, uncommitted secret."""
+    setup_form = form if form is not None else TotpSetupForm()
+    uri = pyotp.TOTP(secret).provisioning_uri(
+        name=current_user.username,
+        issuer_name=current_app.config.get("TOTP_ISSUER_NAME")
+    )
+
+    img = qrcode.make(uri)
+    stream = BytesIO()
+    img.save(stream, format='PNG')
+    qr_data = base64.b64encode(stream.getvalue()).decode('utf-8')
+
+    return render_template(
+        'auth/setup-totp.html',
+        page_title='Setup TOTP MFA',
+        qr_data=qr_data,
+        totp_secret=secret,
+        form=setup_form
+    )
+
+
+@mfa_bp.route('/reset-recovery-codes/', methods=['POST'])
 @login_required
 def reset_recovery_codes():
     """ Generate new recovery codes for the user. """
-    # Clear old codes and generate new codes.
-    for old_code in RecoveryCodes.query.filter_by(user_id=current_user.id).all():
-        db.session.delete(old_code)
-
     # Ensure MFA is active for the user.
-    user = Users.query.get(current_user.id)
+    user = db.session.get(Users, current_user.id)
     user.mfa_active = True
-
-    # Store codes for display in template.
-    codes = ""
-
-    # Create 10 new codes.
-    for _ in range(10):
-        new_code = RecoveryCodes(user_id=current_user.id)
-        code_value = new_code.generate_code()
-        db.session.add(new_code)
-        codes += f"{code_value}\t" if not codes.endswith("\t") else f"{code_value}\n"
+    codes = _generate_recovery_codes(current_user.id)
 
     # Save to database.
     db.session.commit()
@@ -134,7 +159,7 @@ def verify_totp():
 
     return render_template('auth/verify-totp.html', page_title='Verify MFA TOTP Code', form=form)
 
-@mfa_bp.route('/setup-totp/')
+@mfa_bp.route('/setup-totp/', methods=['POST'])
 @login_required
 def setup_totp():
     """ Setup Two-Factor Authentication for the current user. """
@@ -144,85 +169,73 @@ def setup_totp():
         flash("MFA with TOTP is already enabled. Disable it first please!", 'info')
         return redirect(url_for('auth.my_account'))
 
-    form = TotpSetupForm()
-
-    # 1. Get the provisioning URI
-    current_user.generate_totp_secret()
-    db.session.commit()
-    uri = current_user.get_totp_uri()
-
-    # 2. Generate the QR Code image data using 'qrcode'
-    img = qrcode.make(uri)
-    stream = BytesIO()
-    # Save the image to the in-memory buffer as PNG
-    img.save(stream, format='PNG')
-
-    # 3. Encode image data for embedding in HTML
-    qr_data = base64.b64encode(stream.getvalue()).decode('utf-8')
-
-    # Store the URI or secret temporarily if needed for verification in a separate route
-    session['mfa_setup_secret'] = current_user.totp_secret
-
-    return render_template('auth/setup-totp.html',
-                           page_title='Setup TOTP MFA',
-                           qr_data=qr_data,
-                           totp_secret=current_user.totp_secret,
-                           form=form)
+    pending_secret = pyotp.random_base32()
+    session['mfa_setup_secret'] = pending_secret
+    return _render_totp_setup(pending_secret)
 
 @mfa_bp.route('/verify-totp-setup/', methods=['POST'])
 @login_required
 def verify_totp_setup():
     """ Verify the TOTP code entered by the user during setup. """
     form = TotpSetupForm()
+    secret = session.get('mfa_setup_secret')
+
     if form.validate_on_submit():
         token = form.token.data
-        # Use the temporary secret stored in the session for verification
-        secret = session.pop('mfa_setup_secret', None)
         if not secret:
             flash('TOTP MFA setup session expired. Start over.', 'danger')
-            return redirect(url_for('mfa.setup_totp'))
+            return redirect(url_for('auth.my_account'))
 
         # Create a TOTP object with the secret from the session and verify the code
         if pyotp.TOTP(secret).verify(token):
-            # Finalize setup: save the secret (already on the model) and enable MFA
+            # Finalize setup only after the pending secret has been verified.
+            session.pop('mfa_setup_secret', None)
+            current_user.totp_secret = secret
             current_user.mfa_active = True
             current_user.totp_active = True
-            db.session.commit()
             flash('TOTP MFA successfully enabled!', 'success')
 
-            # Prompt user to set up recovery codes if not already present.
+            # Generate recovery codes within this protected POST when none exist.
             if not RecoveryCodes.query.filter_by(user_id=current_user.id).first():
-                return redirect(url_for('mfa.reset_recovery_codes'))
+                codes = _generate_recovery_codes(current_user.id)
+                db.session.commit()
+                return render_template(
+                    "auth/reset-codes.html",
+                    page_title="MFA Recovery Codes",
+                    codes=codes
+                )
+
+            db.session.commit()
             return redirect(url_for('auth.my_account'))
-        else:
-            # If verification fails, we don't save the secret or enable MFA
-            flash('Invalid code. Please try scanning and verifying again.', 'danger')
-            return redirect(url_for('mfa.setup_totp'))
+        # Keep the pending secret available so the user can try again.
+        flash('Invalid code. Please try scanning and verifying again.', 'danger')
+        return _render_totp_setup(secret, form)
 
-    else:
-        flash('Invalid TOTP MFA setup form data.', 'danger')
-        return redirect(url_for('mfa.setup_totp'))
-
-
+    flash('Invalid TOTP MFA setup form data.', 'danger')
+    if secret:
+        return _render_totp_setup(secret, form)
+    return redirect(url_for('auth.my_account'))
 
 
-@mfa_bp.route('/disable-totp/')
+@mfa_bp.route('/disable-totp/', methods=['POST'])
 @login_required
 def disable_totp():
     """ Disable Two-Factor Authentication for the current user. """
     current_user.totp_active = False
-    current_user.generate_totp_secret()
+    current_user.totp_secret = None
+    session.pop('mfa_setup_secret', None)
     db.session.commit()
     flash('Two-Factor TOTP Authentication has been disabled.', 'success')
     return redirect(url_for('auth.my_account'))
 
-@mfa_bp.route('/disable-mfa/')
+@mfa_bp.route('/disable-mfa/', methods=['POST'])
 @login_required
 def disable_mfa():
     """ Disable Multi-Factor Authentication for the current user. """
     current_user.mfa_active = False
     current_user.totp_active = False
     current_user.totp_secret = None
+    session.pop('mfa_setup_secret', None)
     RecoveryCodes.query.filter_by(user_id=current_user.id).delete()
     db.session.commit()
     flash('Multi-Factor Authentication has been disabled.', 'success')

--- a/app/static/js/dashboard.js
+++ b/app/static/js/dashboard.js
@@ -75,7 +75,17 @@ document.addEventListener('DOMContentLoaded', function () {
             } else if (statusData == "Ended") {
                 statusP.innerHTML = `<strong>Current Status: </strong> ${statusData}`;
             } else {
-                statusP.innerHTML = `<strong>Current Status: </strong> ${statusData}<br/><strong>Meeting Code: </strong><a href="/admin/reset-code/${CURRENT_MEETING_ID}" target="_blank">Reset Code</a>`;
+                statusP.innerHTML = `
+                    <strong>Current Status: </strong> ${statusData}<br/>
+                    <strong>Meeting Code: </strong>
+                    <form action="/admin/reset-code/${CURRENT_MEETING_ID}/"
+                          method="POST"
+                          target="_blank"
+                          class="d-inline"
+                          onsubmit="return confirm('Resetting the meeting code will invalidate the current code. Continue?');">
+                        <input type="hidden" name="csrf_token" value="${getCsrfToken()}"/>
+                        <button type="submit" class="btn btn-link p-0 align-baseline">Reset Code</button>
+                    </form>`;
                 if (submitButton) submitButton.innerHTML = "End Meeting";
             }
         } catch (error) {

--- a/app/templates/account.html
+++ b/app/templates/account.html
@@ -67,20 +67,28 @@
                   {% else %}
                     {% set codes_word_1 = 'Generate' %}
                   {% endif %}
-                  <p><a href="{{ url_for('mfa.reset_recovery_codes') }}"><button role="button" class="btn btn-danger blue-link-btn">{{ codes_word_1 }} Recovery Codes</button></a></p>
+                  <form action="{{ url_for('mfa.reset_recovery_codes') }}"
+                        method="POST"
+                        onsubmit="return confirm('This will invalidate all existing recovery codes. Continue?');">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                    <button type="submit" class="btn btn-danger blue-link-btn">{{ codes_word_1 }} Recovery Codes</button>
+                  </form>
                 </td>
                 <td class="align-middle">
                   <!-- TOTP MFA -->
                   {% if current_user.totp_active %}
-                    {% set totp_word_1 = 'Disable' %}
-                    {% set totp_link = url_for('mfa.disable_totp') %}
-                    {% set totp_color = 'red-link-btn' %}
+                    <form action="{{ url_for('mfa.disable_totp') }}"
+                          method="POST"
+                          onsubmit="return confirm('Are you sure you want to disable TOTP authentication?');">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                      <button type="submit" class="btn btn-danger red-link-btn">Disable TOTP MFA (authenticator app)</button>
+                    </form>
                   {% else %}
-                    {% set totp_word_1 = 'Enable' %}
-                    {% set totp_link = url_for('mfa.setup_totp') %}
-                    {% set totp_color = 'blue-link-btn' %}
+                    <form action="{{ url_for('mfa.setup_totp') }}" method="POST">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                      <button type="submit" class="btn btn-danger blue-link-btn">Enable TOTP MFA (authenticator app)</button>
+                    </form>
                   {% endif %}
-                  <p><a href="{{ totp_link }}"><button role="button" class="btn btn-danger {{ totp_color }}">{{ totp_word_1 }} TOTP MFA (authenticator app)</button></a></p>
                 </td>
               </tr>
             </table>
@@ -90,7 +98,12 @@
             {% if current_user.role == 'admin' %}, especially for administrators,{% endif %}
             as it reduces account security.
           </p>
-          <p><a href="{{ url_for('mfa.disable_mfa') }}"><button role="button" class="btn btn-danger red-link-btn">Disable All MFA</button></a></p>
+          <form action="{{ url_for('mfa.disable_mfa') }}"
+                method="POST"
+                onsubmit="return confirm('Are you sure you want to disable all multi-factor authentication?');">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+            <button type="submit" class="btn btn-danger red-link-btn">Disable All MFA</button>
+          </form>
 
         {% else %}
             <!-- MFA Disabled -->
@@ -106,11 +119,19 @@
                 <tr>
                   <td class="align-middle">
                     <!-- MFA Recovery Codes -->
-                    <p><a href="{{ url_for('mfa.reset_recovery_codes') }}"><button role="button" class="btn btn-primary blue-link-btn">Enable MFA with Recovery Codes</button></a></p>
+                    <form action="{{ url_for('mfa.reset_recovery_codes') }}"
+                          method="POST"
+                          onsubmit="return confirm('Generate new recovery codes and enable MFA?');">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                      <button type="submit" class="btn btn-primary blue-link-btn">Enable MFA with Recovery Codes</button>
+                    </form>
                   </td>
                   <td class="align-middle">
                     <!-- TOTP MFA -->
-                    <p><a href="{{ url_for('mfa.setup_totp') }}"><button role="button" class="btn btn-primary blue-link-btn">Enable MFA with TOTP (authenticator app)</button></a></p>
+                    <form action="{{ url_for('mfa.setup_totp') }}" method="POST">
+                      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+                      <button type="submit" class="btn btn-primary blue-link-btn">Enable MFA with TOTP (authenticator app)</button>
+                    </form>
                   </td>
                 </tr>
               </table>

--- a/app/templates/admin/dashboard.html
+++ b/app/templates/admin/dashboard.html
@@ -16,13 +16,26 @@
       <aside class="col-lg-3">
         <h5>Meeting Status</h5>
         <section id="meeting-status">
-        <p id="status-p"><strong>Current Status: </strong>{{ meeting.state | title }}
+        <div id="status-p">
+          <strong>Current Status: </strong>{{ meeting.state | title }}
+          {% if meeting.state == "active" %}
+            <br>
+            <strong>Meeting Code: </strong>
+            <form action="{{ url_for('admin.reset_code', meeting_id=meeting.id) }}"
+                  method="POST"
+                  target="_blank"
+                  class="d-inline"
+                  onsubmit="return confirm('Resetting the meeting code will invalidate the current code. Continue?');">
+              <input type="hidden" name="csrf_token" value="{{ csrf_token() }}"/>
+              <button type="submit" class="btn btn-link p-0 align-baseline">Reset Code</button>
+            </form>
+          {% endif %}
+        </div>
         {% if meeting.state == "not started" %}
           <form action="/admin/start/{{ meeting.id }}/" id="meeting-status-form" method="POST" class="col-lg-8">
             <button type="submit" class="form-control form-control-lg" id="meeting-status-submit">Start Meeting</button>
           </form>
         {% elif meeting.state == "active" %}
-          <strong>Meeting Code: </strong><a href="/admin/reset-code/{{ meeting.id }}" target="_blank">Reset Code</a></p>
           <form action="/admin/end/{{ meeting.id }}/" id="meeting-status-form" method="POST" class="col-lg-8">
             <button type="submit" class="form-control form-control-lg" id="meeting-status-submit">End Meeting</button>
           </form>

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -270,11 +270,11 @@ For POST requests, specify the type of data that should be expected, if any. Thi
         </p>
       </li>
       <li id="route-admin-reset-code">
-        <strong>/admin/reset-code/&lt;int:meeting_id&gt;/ (GET)</strong>
+        <strong>/admin/reset-code/&lt;int:meeting_id&gt;/ (POST)</strong>
         <br>
         <i>reset_code</i>
         <p>
-          Reset the meeting join code for a currently active meeting. Generates a new code and redirects to <a href="#route-admin-show-code">/admin/show-code/</a>. If the meeting is not active, it renders an error page.
+          Reset the meeting join code for a currently active meeting after administrator confirmation. Requires a valid CSRF token, generates a new code, and redirects to <a href="#route-admin-show-code">/admin/show-code/</a>. If the meeting is not active, it renders an error page.
         </p>
       </li>
       <li id="route-admin-show-code">
@@ -652,11 +652,11 @@ For POST requests, specify the type of data that should be expected, if any. Thi
 <p>The following routes handle Multi-Factor Authentication (MFA) functionalities, including TOTP setup and verification, as well as recovery code management. All routes here are contained within the mfa Blueprint (.../mfa/...) and should be restricted to logged-in users. </p>
     <ul>
       <li id="route-mfa-reset-recovery-codes">
-        <strong>/reset-recovery-codes/ (GET)</strong>
+        <strong>/reset-recovery-codes/ (POST)</strong>
         <br>
         <i>reset_recovery_codes</i>
         <p>
-          Remove all of a user's unused recovery codes and generate 10 new recovery codes. 
+          After user confirmation and CSRF validation, remove all of a user's unused recovery codes and generate 10 new recovery codes.
         </p>
         <h4>Template file: auth/reset-codes.html</h4>
         <table>
@@ -694,11 +694,11 @@ For POST requests, specify the type of data that should be expected, if any. Thi
         </table>
       </li>
       <li id="route-mfa-setup-totp">
-        <strong>/setup-totp/ (GET)</strong>
+        <strong>/setup-totp/ (POST)</strong>
         <br>
         <i>setup_totp</i>
         <p>
-          Setup Multi-Factor Authentication (MFA) for a user account. The user is shown the MFA setup page with a QR code and secret key for TOTP configuration as well as a form to verify the TOTP setup. Upon submission of the form, the form data is sent as a POST request to <a href="#route-mfa-verify-totp-setup">mfa.verify_totp_setup</a>.
+          Begin TOTP Multi-Factor Authentication setup after CSRF validation. A new secret remains pending in the user's signed session and is not persisted to the account until verification succeeds. The response shows a QR code, secret key, and verification form that submits to <a href="#route-mfa-verify-totp-setup">mfa.verify_totp_setup</a>.
         </p>
         <h4>Template file: auth/setup-totp.html</h4>
         <table>
@@ -714,23 +714,23 @@ For POST requests, specify the type of data that should be expected, if any. Thi
         <br>
         <i>verify_totp_setup</i>
         <p>
-          Verify the TOTP setup during MFA configuration. The submitted TOTP code from the setup form is verified using cookie data, and if valid, MFA is enabled for the user account. If the user doesn't yet have recovery codes set up, they are redirected to <a href="#route-mfa-reset-recovery-codes">mfa.reset_recovery_codes</a>. Otherwise, redirect to <a href="#route-auth-my-account">auth.my_account</a>. If the code is invalid, an error message is shown on the setup page.
+          Verify the pending TOTP secret during MFA configuration. If the submitted code is valid, the secret is persisted and MFA is enabled. If the user has no recovery codes, 10 codes are generated within the same protected POST and displayed once; otherwise the user is redirected to <a href="#route-auth-my-account">auth.my_account</a>. Invalid codes leave the secret pending and redisplay the setup page.
         </p>
       </li>
       <li id="route-mfa-disable-totp">
-        <strong>/disable-totp/ (GET)</strong>
+        <strong>/disable-totp/ (POST)</strong>
         <br>
         <i>disable_totp</i>
         <p>
-          Disable TOTP-based MFA for the user account. Upon successful disabling, the user is redirected to <a href="#route-auth-my-account">auth.my_account</a>.
+          After user confirmation and CSRF validation, disable TOTP-based MFA and remove its stored secret. Upon success, the user is redirected to <a href="#route-auth-my-account">auth.my_account</a>.
         </p>
       </li>
       <li id="route-mfa-disable-mfa">
-        <strong>/disable-mfa/ (GET)</strong>
+        <strong>/disable-mfa/ (POST)</strong>
         <br>
         <i>disable_mfa</i>
         <p>
-          Disable all MFA methods for the user account, including TOTP and recovery codes. Upon successful disabling, the user is redirected to <a href="#route-auth-my-account">auth.my_account</a>.
+          After user confirmation and CSRF validation, disable all MFA methods for the user account, remove the TOTP secret, and delete all recovery codes. Upon success, the user is redirected to <a href="#route-auth-my-account">auth.my_account</a>.
         </p>
     </ul>
 </details>

--- a/tests/blueprints/test_admin.py
+++ b/tests/blueprints/test_admin.py
@@ -11,12 +11,21 @@ File Purpose: Pytest for the blueprints/admin endpoints.
 
 import io
 import os
+import re
 from datetime import datetime, timedelta
 
 from flask import current_app, get_flashed_messages
 
 from app.models import Attachments, Attendees, Meetings, Minutes, Users
 from tests.conftest import app as flask_app, db  # Import the app fixture for context in tests.
+
+
+def get_csrf_token(response):
+    """Extract a Flask-WTF CSRF token from a rendered form."""
+    match = re.search(rb'name="csrf_token" value="([^"]+)"', response.data)
+    assert match is not None
+    return match.group(1).decode()
+
 
 def test_get_last_attended_date(flask_app):
     """ Test the get_last_attended_date function. """
@@ -236,7 +245,7 @@ def test_event_start(flask_app):
         assert start_response_again.status_code == 400
 
 def test_reset_code(flask_app):
-    """ Test the /admin/reset-code/ endpoint. """
+    """Test resetting a meeting code requires POST and a valid CSRF token."""
     with flask_app.app_context():
         # Create a test admin user.
         admin_user = Users(username="adminuser", role="admin", activated=True)
@@ -245,7 +254,13 @@ def test_reset_code(flask_app):
         db.session.commit()
 
         # Create a test meeting to reset the code for.
-        meeting = Meetings(title="Test Meeting", state="active", description="Test Meeting Description", host="adminuser")
+        meeting = Meetings(
+            title="Test Meeting",
+            state="active",
+            description="Test Meeting Description",
+            host="adminuser",
+            code_hash="original-code-hash"
+        )
         db.session.add(meeting)
         db.session.commit()
 
@@ -255,19 +270,45 @@ def test_reset_code(flask_app):
 
         # Test access without login.
         test_client = flask_app.test_client()
-        response = test_client.get(f"/admin/reset-code/{meeting.id}/", follow_redirects=True)
+        response = test_client.post(f"/admin/reset-code/{meeting.id}/", follow_redirects=True)
         assert response.status_code == 401  # Unauthorized.
 
         # Log in as the admin user.
         login_response = test_client.post("/login/", data={"username": "adminuser", "password": "testpassword"}, follow_redirects=True)
         assert login_response.status_code == 200
+        flask_app.config["WTF_CSRF_ENABLED"] = True
 
-        # Test access to the reset code endpoint after login.
-        reset_code_response = test_client.get(f"/admin/reset-code/{meeting.id}/", follow_redirects=True)
+        dashboard_response = test_client.get(f"/admin/dashboard/{meeting.id}/")
+        csrf_token = get_csrf_token(dashboard_response)
+        assert b"Resetting the meeting code will invalidate the current code." in dashboard_response.data
+
+        get_response = test_client.get(f"/admin/reset-code/{meeting.id}/")
+        assert get_response.status_code == 405
+        missing_token_response = test_client.post(f"/admin/reset-code/{meeting.id}/")
+        assert missing_token_response.status_code == 400
+        invalid_token_response = test_client.post(
+            f"/admin/reset-code/{meeting.id}/",
+            data={"csrf_token": "invalid"}
+        )
+        assert invalid_token_response.status_code == 400
+        db.session.refresh(meeting)
+        assert meeting.code_hash == "original-code-hash"
+
+        reset_code_response = test_client.post(
+            f"/admin/reset-code/{meeting.id}/",
+            data={"csrf_token": csrf_token},
+            follow_redirects=True
+        )
         assert reset_code_response.status_code == 200
+        db.session.refresh(meeting)
+        assert meeting.code_hash != "original-code-hash"
 
         # Test resetting the code for an inactive meeting.
-        reset_code_response_inactive = test_client.get(f"/admin/reset-code/{inactive_meeting.id}/", follow_redirects=True)
+        reset_code_response_inactive = test_client.post(
+            f"/admin/reset-code/{inactive_meeting.id}/",
+            data={"csrf_token": csrf_token},
+            follow_redirects=True
+        )
         assert reset_code_response_inactive.status_code == 400
 
 def test_show_code(flask_app):

--- a/tests/blueprints/test_mfa.py
+++ b/tests/blueprints/test_mfa.py
@@ -11,6 +11,7 @@ File Purpose: Pytest for the blueprints/mfa endpoints.
 
 import io
 import os
+import re
 from datetime import datetime, timedelta
 
 from flask import current_app, get_flashed_messages
@@ -19,40 +20,83 @@ import pyotp
 from app.models import Attachments, Attendees, Meetings, Minutes, RecoveryCodes, Users
 from tests.conftest import app as flask_app, db  # Import the app fixture for context in tests.
 
+
+def get_csrf_token(response):
+    """Extract a Flask-WTF CSRF token from a rendered form."""
+    match = re.search(rb'name="csrf_token" value="([^"]+)"', response.data)
+    assert match is not None
+    return match.group(1).decode()
+
+
 def test_mfa_reset_recovery_codes(flask_app):
-    """ Test the /mfa/reset-recovery-codes/ endpoint. """
+    """Test recovery-code replacement requires POST and a valid CSRF token."""
     with flask_app.app_context():
-        # Create a test user and log them in.
         user = Users(username="testuser", role="user", activated=True)
         user.set_password("password")
+        old_code = RecoveryCodes(user_id=1)
+        old_code.generate_code()
         db.session.add(user)
+        db.session.commit()
+        old_code.user_id = user.id
+        db.session.add(old_code)
         db.session.commit()
 
         test_client = flask_app.test_client()
-        login_response = test_client.post("/login/", data={"username": "testuser", "password": "password"}, follow_redirects=True)
-        assert login_response.status_code == 200
+        unauthenticated_response = test_client.post("/mfa/reset-recovery-codes/")
+        assert unauthenticated_response.status_code == 401
 
-        # Test resetting recovery codes.
-        response = test_client.get("/mfa/reset-recovery-codes/", follow_redirects=True)
+        login_response = test_client.post(
+            "/login/",
+            data={"username": "testuser", "password": "password"},
+            follow_redirects=True
+        )
+        assert login_response.status_code == 200
+        flask_app.config["WTF_CSRF_ENABLED"] = True
+
+        account_response = test_client.get("/my-account/")
+        csrf_token = get_csrf_token(account_response)
+        assert b"method=\"POST\"" in account_response.data
+        original_hashes = {
+            code.code_hash
+            for code in RecoveryCodes.query.filter_by(user_id=user.id).all()
+        }
+
+        get_response = test_client.get("/mfa/reset-recovery-codes/")
+        assert get_response.status_code == 405
+
+        missing_token_response = test_client.post("/mfa/reset-recovery-codes/")
+        assert missing_token_response.status_code == 400
+        invalid_token_response = test_client.post(
+            "/mfa/reset-recovery-codes/",
+            data={"csrf_token": "invalid"}
+        )
+        assert invalid_token_response.status_code == 400
+        unchanged_hashes = {
+            code.code_hash
+            for code in RecoveryCodes.query.filter_by(user_id=user.id).all()
+        }
+        assert unchanged_hashes == original_hashes
+
+        response = test_client.post(
+            "/mfa/reset-recovery-codes/",
+            data={"csrf_token": csrf_token}
+        )
         assert response.status_code == 200
         assert b"Store these codes securely." in response.data
 
-        # Test that 10 new codes were generated in the database.
-        with flask_app.app_context():
-            codes = RecoveryCodes.query.filter_by(user_id=user.id).all()
-            assert len(codes) == 10
-        
-        # Test that old codes are deleted when new codes are generated.
-        with flask_app.app_context():
-            # Generate new codes again.
-            response = test_client.get("/mfa/reset-recovery-codes/", follow_redirects=True)
-            assert response.status_code == 200
+        codes = RecoveryCodes.query.filter_by(user_id=user.id).all()
+        assert len(codes) == 10
+        first_hashes = {code.code_hash for code in codes}
+        assert first_hashes.isdisjoint(original_hashes)
 
-            # Check that there are still only 10 codes and they are all new.
-            codes_after = RecoveryCodes.query.filter_by(user_id=user.id).all()
-            assert len(codes_after) == 10
-            for code in codes_after:
-                assert code not in codes  # Ensure they are new codes.
+        second_response = test_client.post(
+            "/mfa/reset-recovery-codes/",
+            data={"csrf_token": csrf_token}
+        )
+        assert second_response.status_code == 200
+        codes_after = RecoveryCodes.query.filter_by(user_id=user.id).all()
+        assert len(codes_after) == 10
+        assert {code.code_hash for code in codes_after}.isdisjoint(first_hashes)
 
 def test_verify_recovery_code_success(flask_app):
     """Test verifying a valid recovery code logs the user in and deletes the code."""
@@ -214,12 +258,12 @@ def test_setup_totp_already_active(flask_app):
             sess['_user_id'] = str(user.id)  # Standard Flask-Login key.
 
         with test_client:
-            response = test_client.get("/mfa/setup-totp/", follow_redirects=False)
+            response = test_client.post("/mfa/setup-totp/", follow_redirects=False)
             assert response.status_code == 302
             assert get_flashed_messages() == ["MFA with TOTP is already enabled. Disable it first please!"]
 
 def test_setup_totp_success(flask_app):
-    """Test that an authenticated user without TOTP active generates a secret, QR code, and populates the session."""
+    """Test TOTP setup requires valid CSRF and keeps its secret pending."""
     with flask_app.app_context():
         user = Users(username="newuser", role="user", activated=True, totp_active=False)
         user.set_password("password")
@@ -231,17 +275,38 @@ def test_setup_totp_success(flask_app):
         with test_client.session_transaction() as sess:
             sess['_user_id'] = str(user.id)
 
-        response = test_client.get("/mfa/setup-totp/", follow_redirects=False)
-        assert response.status_code == 200
+        flask_app.config["WTF_CSRF_ENABLED"] = True
+        account_response = test_client.get("/my-account/")
+        csrf_token = get_csrf_token(account_response)
 
-        # Verify the database model updated and generated a secret.
-        with flask_app.app_context():
-            updated_user = Users.query.get(user.id)
-            assert updated_user.totp_secret is not None
+        get_response = test_client.get("/mfa/setup-totp/")
+        assert get_response.status_code == 405
+        missing_token_response = test_client.post("/mfa/setup-totp/")
+        assert missing_token_response.status_code == 400
+        invalid_token_response = test_client.post(
+            "/mfa/setup-totp/",
+            data={"csrf_token": "invalid"}
+        )
+        assert invalid_token_response.status_code == 400
 
-        # Verify the temporary secret was dropped into the session transaction queue.
+        db.session.refresh(user)
+        assert user.totp_secret is None
         with test_client.session_transaction() as sess:
-            assert sess.get('mfa_setup_secret') == updated_user.totp_secret
+            assert sess.get('mfa_setup_secret') is None
+
+        response = test_client.post(
+            "/mfa/setup-totp/",
+            data={"csrf_token": csrf_token},
+            follow_redirects=False
+        )
+        assert response.status_code == 200
+        assert b"TOTP Setup QR Code" in response.data
+
+        db.session.refresh(user)
+        assert user.totp_secret is None
+
+        with test_client.session_transaction() as sess:
+            assert sess.get('mfa_setup_secret') is not None
 
 def test_setup_totp_unauthenticated(flask_app):
     """Test that an unauthenticated user cannot access the setup route."""
@@ -249,48 +314,48 @@ def test_setup_totp_unauthenticated(flask_app):
         # Completely fresh, empty client context.
         test_client = flask_app.test_client()
 
-        response = test_client.get("/mfa/setup-totp/", follow_redirects=False)
-
-        # Throw a 401 unauthorized.
-        assert response.status_code == 401
+        get_response = test_client.get("/mfa/setup-totp/", follow_redirects=False)
+        assert get_response.status_code == 405
+        post_response = test_client.post("/mfa/setup-totp/", follow_redirects=False)
+        assert post_response.status_code == 401
 
 def test_verify_totp_setup_success_redirect_recovery(flask_app):
-    """Test valid token activates TOTP and redirects to recovery code generation if missing."""
+    """Test valid TOTP setup safely persists the secret and creates recovery codes."""
     with flask_app.app_context():
         user = Users(username="setupuser1", role="user", activated=True, totp_active=False)
         user.set_password("password")
-        user.totp_secret = pyotp.random_base32()
         db.session.add(user)
         db.session.commit()
+        pending_secret = pyotp.random_base32()
 
         test_client = flask_app.test_client()
 
         with test_client.session_transaction() as sess:
             sess['_user_id'] = str(user.id)
-            sess['mfa_setup_secret'] = user.totp_secret
+            sess['mfa_setup_secret'] = pending_secret
 
-        # Generate a valid code using the shared secret.
-        totp = pyotp.TOTP(user.totp_secret)
+        totp = pyotp.TOTP(pending_secret)
         valid_token = totp.now()
 
         response = test_client.post("/mfa/verify-totp-setup/", data={"token": valid_token}, follow_redirects=False)
 
-        # Should redirect to reset_recovery_codes because no recovery codes exist yet.
-        assert response.status_code == 302
+        assert response.status_code == 200
+        assert b"Store these codes securely." in response.data
 
-        with flask_app.app_context():
-            updated_user = Users.query.get(user.id)
-            assert updated_user.mfa_active is True
-            assert updated_user.totp_active is True
+        db.session.refresh(user)
+        assert user.mfa_active is True
+        assert user.totp_active is True
+        assert user.totp_secret == pending_secret
+        assert RecoveryCodes.query.filter_by(user_id=user.id).count() == 10
 
 def test_verify_totp_setup_success_redirect_account(flask_app):
     """Test valid token redirects straight to account if recovery codes already exist."""
     with flask_app.app_context():
         user = Users(username="setupuser2", role="user", activated=True, totp_active=False)
         user.set_password("password")
-        user.totp_secret = pyotp.random_base32()
         db.session.add(user)
         db.session.commit()
+        pending_secret = pyotp.random_base32()
 
         # Mock an existing recovery code
         dummy_code = RecoveryCodes(user_id=user.id, code_hash="dummy_hash")
@@ -301,15 +366,17 @@ def test_verify_totp_setup_success_redirect_account(flask_app):
 
         with test_client.session_transaction() as sess:
             sess['_user_id'] = str(user.id)
-            sess['mfa_setup_secret'] = user.totp_secret
+            sess['mfa_setup_secret'] = pending_secret
 
-        totp = pyotp.TOTP(user.totp_secret)
+        totp = pyotp.TOTP(pending_secret)
         valid_token = totp.now()
 
         response = test_client.post("/mfa/verify-totp-setup/", data={"token": valid_token}, follow_redirects=False)
 
         # Should bypass recovery codes setup and head directly to account view.
         assert response.status_code == 302
+        db.session.refresh(user)
+        assert user.totp_secret == pending_secret
 
 def test_verify_totp_setup_session_expired(flask_app):
     """Test verification fails gracefully if the setup secret session key is missing."""
@@ -331,28 +398,30 @@ def test_verify_totp_setup_session_expired(flask_app):
             assert get_flashed_messages() == ['TOTP MFA setup session expired. Start over.']
 
 def test_verify_totp_setup_invalid_code(flask_app):
-    """Test that an incorrect token does not activate MFA and redirects back to setup."""
+    """Test an incorrect token leaves the pending secret uncommitted."""
     with flask_app.app_context():
         user = Users(username="setupuser4", role="user", activated=True, totp_active=False)
         user.set_password("password")
-        user.totp_secret = pyotp.random_base32()
         db.session.add(user)
         db.session.commit()
+        pending_secret = pyotp.random_base32()
 
         test_client = flask_app.test_client()
 
         with test_client.session_transaction() as sess:
             sess['_user_id'] = str(user.id)
-            sess['mfa_setup_secret'] = user.totp_secret
+            sess['mfa_setup_secret'] = pending_secret
 
         with test_client:
             response = test_client.post("/mfa/verify-totp-setup/", data={"token": "000000"}, follow_redirects=False)
-            assert response.status_code == 302
+            assert response.status_code == 200
             assert get_flashed_messages() == ['Invalid code. Please try scanning and verifying again.']
 
-        with flask_app.app_context():
-            updated_user = Users.query.get(user.id)
-            assert updated_user.totp_active is False
+        db.session.refresh(user)
+        assert user.totp_active is False
+        assert user.totp_secret is None
+        with test_client.session_transaction() as sess:
+            assert sess['mfa_setup_secret'] == pending_secret
 
 def test_verify_totp_setup_invalid_form(flask_app):
     """Test submission handling when form validation completely fails (empty token payload)."""
@@ -361,22 +430,30 @@ def test_verify_totp_setup_invalid_form(flask_app):
         user.set_password("password")
         db.session.add(user)
         db.session.commit()
+        pending_secret = pyotp.random_base32()
 
         test_client = flask_app.test_client()
 
         with test_client.session_transaction() as sess:
             sess['_user_id'] = str(user.id)
+            sess['mfa_setup_secret'] = pending_secret
 
         with test_client:
             # Submitting completely blank form fields.
             response = test_client.post("/mfa/verify-totp-setup/", data={}, follow_redirects=False)
-            assert response.status_code == 302
+            assert response.status_code == 200
             assert get_flashed_messages() == ['Invalid TOTP MFA setup form data.']
 
 def test_disable_totp_success(flask_app):
-    """Test that an authenticated user with TOTP active can disable it successfully."""
+    """Test disabling TOTP requires POST and a valid CSRF token."""
     with flask_app.app_context():
-        user = Users(username="disableuser", role="user", activated=True, totp_active=True)
+        user = Users(
+            username="disableuser",
+            role="user",
+            activated=True,
+            mfa_active=True,
+            totp_active=True
+        )
         user.set_password("password")
         user.totp_secret = pyotp.random_base32()
         db.session.add(user)
@@ -387,15 +464,37 @@ def test_disable_totp_success(flask_app):
         with test_client.session_transaction() as sess:
             sess['_user_id'] = str(user.id)
 
+        flask_app.config["WTF_CSRF_ENABLED"] = True
+        account_response = test_client.get("/my-account/")
+        csrf_token = get_csrf_token(account_response)
+        assert b"Are you sure you want to disable TOTP authentication?" in account_response.data
+        original_secret = user.totp_secret
+
+        get_response = test_client.get("/mfa/disable-totp/")
+        assert get_response.status_code == 405
+        missing_token_response = test_client.post("/mfa/disable-totp/")
+        assert missing_token_response.status_code == 400
+        invalid_token_response = test_client.post(
+            "/mfa/disable-totp/",
+            data={"csrf_token": "invalid"}
+        )
+        assert invalid_token_response.status_code == 400
+        db.session.refresh(user)
+        assert user.totp_active is True
+        assert user.totp_secret == original_secret
+
         with test_client:
-            response = test_client.get("/mfa/disable-totp/", follow_redirects=True)
+            response = test_client.post(
+                "/mfa/disable-totp/",
+                data={"csrf_token": csrf_token},
+                follow_redirects=True
+            )
             assert response.status_code == 200
             assert "Two-Factor TOTP Authentication has been disabled." in get_flashed_messages()
 
-        # Verify the database model updated and TOTP is now inactive.
-        with flask_app.app_context():
-            updated_user = Users.query.get(user.id)
-            assert not updated_user.totp_active
+        db.session.refresh(user)
+        assert not user.totp_active
+        assert user.totp_secret is None
 
 def test_disable_totp_unauthenticated(flask_app):
     """Test that an unauthenticated user cannot access the disable route."""
@@ -403,13 +502,13 @@ def test_disable_totp_unauthenticated(flask_app):
         # Completely fresh, empty client context.
         test_client = flask_app.test_client()
 
-        response = test_client.get("/mfa/disable-totp/", follow_redirects=False)
-
-        # Throw a 401 unauthorized.
-        assert response.status_code == 401
+        get_response = test_client.get("/mfa/disable-totp/", follow_redirects=False)
+        assert get_response.status_code == 405
+        post_response = test_client.post("/mfa/disable-totp/", follow_redirects=False)
+        assert post_response.status_code == 401
 
 def test_disable_mfa_success(flask_app):
-    """Test that an authenticated user with MFA active can disable it successfully."""
+    """Test disabling all MFA requires POST and a valid CSRF token."""
     with flask_app.app_context():
         user = Users(username="disablemfauser", role="user", activated=True, mfa_active=True, totp_active=True)
         user.set_password("password")
@@ -429,21 +528,48 @@ def test_disable_mfa_success(flask_app):
         with test_client.session_transaction() as sess:
             sess['_user_id'] = str(user.id)
 
+        flask_app.config["WTF_CSRF_ENABLED"] = True
+        account_response = test_client.get("/my-account/")
+        csrf_token = get_csrf_token(account_response)
+        assert b"Are you sure you want to disable all multi-factor authentication?" in account_response.data
+        original_secret = user.totp_secret
+        original_code_hashes = {
+            code.code_hash
+            for code in RecoveryCodes.query.filter_by(user_id=user.id).all()
+        }
+
+        get_response = test_client.get("/mfa/disable-mfa/")
+        assert get_response.status_code == 405
+        missing_token_response = test_client.post("/mfa/disable-mfa/")
+        assert missing_token_response.status_code == 400
+        invalid_token_response = test_client.post(
+            "/mfa/disable-mfa/",
+            data={"csrf_token": "invalid"}
+        )
+        assert invalid_token_response.status_code == 400
+        db.session.refresh(user)
+        assert user.mfa_active is True
+        assert user.totp_active is True
+        assert user.totp_secret == original_secret
+        assert {
+            code.code_hash
+            for code in RecoveryCodes.query.filter_by(user_id=user.id).all()
+        } == original_code_hashes
+
         with test_client:
-            response = test_client.get("/mfa/disable-mfa/", follow_redirects=True)
+            response = test_client.post(
+                "/mfa/disable-mfa/",
+                data={"csrf_token": csrf_token},
+                follow_redirects=True
+            )
             assert response.status_code == 200
             assert "Multi-Factor Authentication has been disabled." in get_flashed_messages()
 
-        # Verify the database model updated and MFA is now inactive.
-        with flask_app.app_context():
-            updated_user = Users.query.get(user.id)
-            assert not updated_user.mfa_active
-            assert not updated_user.totp_active
-            assert updated_user.totp_secret is None
-
-            # Verify that recovery codes are deleted.
-            codes_after = RecoveryCodes.query.filter_by(user_id=user.id).all()
-            assert len(codes_after) == 0
+        db.session.refresh(user)
+        assert not user.mfa_active
+        assert not user.totp_active
+        assert user.totp_secret is None
+        assert RecoveryCodes.query.filter_by(user_id=user.id).count() == 0
 
 def test_disable_mfa_unauthenticated(flask_app):
     """Test that an unauthenticated user cannot access the disable MFA route."""
@@ -451,7 +577,7 @@ def test_disable_mfa_unauthenticated(flask_app):
         # Completely fresh, empty client context.
         test_client = flask_app.test_client()
 
-        response = test_client.get("/mfa/disable-mfa/", follow_redirects=False)
-
-        # Throw a 401 unauthorized.
-        assert response.status_code == 401
+        get_response = test_client.get("/mfa/disable-mfa/", follow_redirects=False)
+        assert get_response.status_code == 405
+        post_response = test_client.post("/mfa/disable-mfa/", follow_redirects=False)
+        assert post_response.status_code == 401


### PR DESCRIPTION
Add CSRF-protected POST requests and confirmation dialogs to sensitive MFA and meeting code actions. Also keeps TOTP secrets pending until verification succeeds and adds tests for missing, invalid, and valid CSRF tokens. Close #147 